### PR TITLE
Fix docker push workflow permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,11 +5,6 @@ on:
     branches: [ main ]
   pull_request:
 
-permissions:
-  contents: read
-  pull-requests: read
-  checks: write
-
 jobs:
   setup:
     outputs:
@@ -49,6 +44,8 @@ jobs:
   push:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [setup, build]
+    permissions:
+      statuses: write
     environment: dockerhub
     concurrency: dockerhub
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What
  Remove global workflow permissions (contents read, pull-requests read, checks write) and add job-specific statuses write permission to the push job of the docker workflow.

  ### Why
  The push job requires statuses write permission to write a commit status for the commit that gets built, where that status will include hte name of the docker hub image that's been pushed, while the previous global permissions were overly broad and unnecessary for other jobs as I think they were copy-pasted from the wrong workflow.

For #4