### PR TITLE
Remove unused linter configuration settings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,9 +28,6 @@ linters:
     funlen:
       lines: 100
       statements: 50
-    goconst:
-      min-len: 2
-      min-occurrences: 3
     gocritic:
       disabled-checks:
         - dupImport
@@ -53,8 +50,6 @@ linters:
             - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
             - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
             - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
-    lll:
-      line-length: 140
     misspell:
       locale: US
     nolintlint:


### PR DESCRIPTION
### What
  Remove goconst and lll linter configuration settings from golangci.yml.

  ### Why
  These linters are not enabled in the linters list, making their configuration settings unnecessary. They were disabled in https://github.com/stellar/friendbot/pull/14 but in that change removing the now unused config got missed.