### PR TITLE
Retry on tx_bad_seq during minion account creation

### DIFF
--- a/init_friendbot.go
+++ b/init_friendbot.go
@@ -164,8 +164,9 @@ func createMinionAccounts(botAccount internal.Account, botKeypair *keypair.Full,
 		if err != nil {
 			switch e := err.(type) {
 			case internal.NetworkError:
-				// If we hit an error here due to network congestion, try again until we hit max # of retries allowed
-				if e.IsTimeout() {
+				// If we hit an error here due to network congestion, or a bad seq on
+				// the source account, try again until we hit max # of retries allowed
+				if e.IsTimeout() || e.IsBadSequence() {
 					err = errors.Wrap(err, "submitting create accounts tx")
 					if currentSubmitTxRetry >= submitTxRetriesAllowed {
 						return minions, errors.Wrap(err, fmt.Sprintf("after retrying %d times", currentSubmitTxRetry))


### PR DESCRIPTION
### What
Add bad sequence error handling to the retry logic in createMinionAccounts. Treat tx_bad_seq errors the same as timeout errors by retrying the transaction.

### Why
Friendbot fails to start when RPC returns stale sequence numbers due to ingestion lag. This occurs when the bot account has pending transactions from other startup operations (e.g., network config upgrades in Quickstart). The error is transient and recoverable by retrying.

Close #34